### PR TITLE
Create Initial Example of Deferred Library Loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Don’t commit the following directories created by pub.
+.buildlog
+.pub/
+build/
+packages
+.packages
+
+# Or the files created by dart2js.
+*.dart.js
+*.js_
+*.js.deps
+*.js.map
+
+# Include when developing application packages.
+pubspec.lock
+
+# Custom rules:
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
-# deferred-loading-example
-A simple example of deferred loading in Dart.
+# Dart Deferred Loading Example
+A simple example of deferred loading in Dart. To build and run the example, do the following:
+
+```
+pub get
+pub serve
+```
+
+Then you can load the example in your favorite browser `http://localhost:8080`. Click the button labeled "Load". It will then deferred load a library which, when it is loaded, will display a "hello" message.

--- a/lib/lib_a.dart
+++ b/lib/lib_a.dart
@@ -1,0 +1,5 @@
+library lib_a;
+
+import 'package:react/react.dart' as react;
+
+part 'src/components/loader.dart';

--- a/lib/lib_b.dart
+++ b/lib/lib_b.dart
@@ -1,0 +1,5 @@
+library lib_b;
+
+import 'package:react/react.dart' as react;
+
+part 'src/components/hello.dart';

--- a/lib/src/components/hello.dart
+++ b/lib/src/components/hello.dart
@@ -1,0 +1,9 @@
+part of lib_b;
+
+var helloComponent = react.registerComponent(() => new _HelloComponent());
+
+class _HelloComponent extends react.Component {
+  render() {
+    return react.div({}, 'Hi, I was deferred loaded!');
+  }
+}

--- a/lib/src/components/loader.dart
+++ b/lib/src/components/loader.dart
@@ -1,0 +1,11 @@
+part of lib_a;
+
+var loaderComponent = react.registerComponent(() => new _LoaderComponent());
+
+class _LoaderComponent extends react.Component {
+  Function get loadHandler => props['loadHandler'];
+
+  render() {
+    return react.button({'onClick': loadHandler}, 'Load');
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,8 @@
+name: deferred_loading_example
+version: 0.0.1
+description: An example of deferred library loading in Dart.
+dependencies:
+  browser: any
+  react: "^0.8.2"
+environment:
+  sdk: ">=1.9.0 <2.0.0"

--- a/web/example.dart
+++ b/web/example.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+import 'dart:html';
+
+import 'package:react/react.dart' as react;
+import 'package:react/react_client.dart' as reactClient;
+
+import 'package:deferred_loading_example/lib_a.dart';
+import 'package:deferred_loading_example/lib_b.dart' deferred as libB;
+
+void main() {
+  reactClient.setClientConfiguration();
+  var loader = loaderComponent({'loadHandler': onLoad});
+  react.render(loader, querySelector('#toolbar-container'));
+}
+
+Future onLoad(_) async {
+  print('load button clicked');
+  await libB.loadLibrary();
+  var hello = libB.helloComponent({});
+  react.render(hello, querySelector('#body-container'));
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Dart Deferred Loading Example</title>
+
+    <!-- javascript -->
+    <script src="packages/react/react.js"></script>
+</head>
+<body>
+<div id="toolbar-container"></div>
+<div id="body-container"></div>
+
+<!-- app scripts -->
+<script type="application/dart" src="example.dart"></script>
+<script src="packages/browser/dart.js"></script>
+</body>
+</html>


### PR DESCRIPTION
# Problem:

Create an example of deferred loading of Dart libraries.
# Testing:
1. `pub get`
2. `pub serve`
3. Open `http://localhost:8080` and click the `Load` button
4. Confirm via the network tab that additional code is downloaded
5. Confirm a message is displayed saying, "Hi, I was deferred loaded!"
